### PR TITLE
fix: generate state if no state is passed ios

### DIFF
--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -329,7 +329,7 @@ RCT_REMAP_METHOD(logout,
                                                      scope:[OIDScopeUtilities scopesWithArray:scopes]
                                                redirectURL:[NSURL URLWithString:redirectUrl]
                                               responseType:OIDResponseTypeCode
-                                                     state:[[self class] generateState]
+                                                     state: additionalParameters[@"state"] ? nil : [[self class] generateState]
                                                      nonce:nonce
                                               codeVerifier:codeVerifier
                                              codeChallenge:codeChallenge


### PR DESCRIPTION
Fix applied from https://github.com/FormidableLabs/react-native-app-auth/pull/735/

Fix for solving mlsl auth flow state mismatch issue 
